### PR TITLE
Improve org of staging/output files

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.12
+current_version = 0.1.13
 commit = False
 tag = False
 tag_name = {new_version}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 gb_workdir*
 gravitybee*json
 # executable
+.gravitybee/
 *-x86_64
 *-x86_64.exe
 gravitybee-environs*

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,22 @@
 CHANGE LOG
 ==========
 
+0.1.13 - 2018.06.04
+-------------------
+* [ENHANCEMENT] Rearrange files created by GravityBee to all be
+  contained in a ``.gravitybee`` subdirectory of the current
+  directory.
+* [ENHANCEMENT] Place the distribution artifacts in the staging
+  directory, with a default value of ``.gravitybee/dist``.
+* [ENHANCEMENT] Add option ``--staging-dir`` to specify directory
+  where artifact staging should take place and export another
+  environment variable ``GB_ENV_STAGING_DIR``.
+* [ENHANCEMENT] Add option ``--with-latest`` to allow creation of
+  a second artifact staging directory called "latest" containing
+  the artifacts renamed with "latest" in the place of the version.
+* [ENHANCEMENT] Add option ``--sha-format`` to allow custom naming
+  of the SHA hash file.
+
 0.1.12 - 2018.05.29
 -------------------
 * [ENHANCEMENT] Add OS and machine type to the SHA256 hash file (to

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ GB_PKG_DIR        --pkg-dir, -p         The relative or absolute path of the pac
                                         containing your application.
                                         This directory must contain a ``setup.py`` file.
                                         *Default:* ``.``
-GB_VERBOSE        --verbose, -v         Verbose mode.
+GB_VERBOSE        --verbose, -v         Flag for verbose mode.
 GB_EXTRA_DATA     --extra-data, -e      Relative to package directory, any extra
                                         directories or files that need
                                         to be included, that wouldn't normally be
@@ -104,32 +104,58 @@ GB_WORK_DIR       --work-dir, -w        Directory for use by GravityBee to build
                                         application. Cannot be an existing
                                         directory as it will be deleted if the clean
                                         option is used.
-                                        *Default:* ``gb_workdir_<uuid>``
-GB_CLEAN          --clean, -c           Whether to clean up the work directory after
-                                        the build. If used, GravityBee will copy the
-                                        built standalone application to the current
-                                        directory before deleting.
+                                        *Default:* ``.gravitybee/build``
+GB_CLEAN          --clean, -c           Flag indicating whether to
+                                        clean up the work directory
+                                        after
+                                        the build. If used, GravityBee
+                                        will copy the
+                                        built standalone application
+                                        to top-level GravityBee
+                                        directory (``.gravitybee``)
+                                        before deleting.
                                         *Default: Not*
 GB_NAME_FORMAT    --name-format, -f     Format to be used in naming the standalone
                                         application. Must include
                                         {an}, {v}, {os}, {m}
                                         for app name, version, os, and machine
-                                        type respectively.
+                                        type respectively. On Windows, ``.exe``
+                                        will be added automatidally.
                                         *Default:* ``{an}-{v}-standalone-{os}-{m}``
-GB_NO_FILE        --no-file             Do not write the output files (see below).
-                                        If the ``--sha`` flag is used to
+GB_SHA_FORMAT     --sha-format          Format to be used in naming the SHA hash
+                                        file. Must include
+                                        {an}, {v}, {os}, {m}
+                                        for app name, version, os, and machine
+                                        type respectively.
+                                        *Default:* ``{an}-{v}-sha256-{os}-{m}.json``
+GB_NO_FILE        --no-file             Flag indicating to not write
+                                        the output files (see below).
+                                        If the ``--sha`` option is used to
                                         write a
-                                        hash to a file, that file will still be
+                                        hash to a file, that file will
+                                        still be
                                         written regardless.
                                         *Default: Will write
                                         files*
-GB_SHA            --sha                 Where to put SHA256
+GB_SHA            --sha                 Option of where to put SHA256
                                         hash for generated file.
                                         Valid options are ``file``
                                         (create a separate file with
                                         hash), or ``info`` (only
                                         include the hash in the file
                                         info output). *Default:* ``info``
+GB_STAGING_DIR    --staging-dir         Option to indicate where GravityBee
+                                        should stage build artifacts
+                                        (standalone executable and hash
+                                        file). Two subdirectories will
+                                        be created, one based on version
+                                        and the other called "latest."
+                                        *Default:* ``.gravitybee/dist``
+GB_WITH_LATEST    --with-latest         Flag to indicate if GravityBee
+                                        should create a "latest"
+                                        directory in the staging area
+                                        with a copy of the artifacts.
+                                        *Default: Not*
 ================  ==================    ==========================================
 
 

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -9,15 +9,19 @@ read -n 1 -s -r -p "Press any key to continue"
 
 echo
 
+rm -rf .gravitybee
+rm -rf .pytest_cache
+
 rm -rf gravitybee/__pycache__
 
-rm -rf gb_workdir_*
+rm -rf tests/__pycache__
+rm -rf tests/gbtestapp/src/gbtestapp/__pycache__
+rm -rf tests/gbtestapp/src/gbtestapp/gbextradata/__pycache__
+rm -rf tests/gbtestapp/.pytest_cache
+rm -rf tests/gbtestapp/src/gbtestapp.egg-info
+
+rm -rf gbtestapp-4.2.6*
+
 rm -rf gravitybee.egg-info
 
-rm gravitybee-environs*
-rm gravitybee-*json
-rm gbtestapp-4.2.6*
-
-rm tests/gbtestapp/gravitybee-environs*
-rm tests/gbtestapp/gravitybee-*json
-rm tests/gbtestapp/gbtestapp-4.2.6*
+rm -rf tests/gbtestapp/.gravitybee

--- a/gravitybee/cli.py
+++ b/gravitybee/cli.py
@@ -105,7 +105,17 @@ click.disable_unicode_literals_warning = True
         + "application. Must include {an}, {v}, {os}, {m} "
         + "for app name, version, os, and machine type "
         + "respectively."
-) 
+)
+@click.option(
+    '--sha-format', 
+    'sha_format', 
+    default=None,
+    envvar='GB_SHA_FORMAT',
+    help="Format to be used in naming the SHA hash "
+        + "file. Must include {an}, {v}, {os}, {m} "
+        + "for app name, version, os, and machine type "
+        + "respectively."
+)  
 @click.option(
     '--no-file', 
     'no_file', 
@@ -126,6 +136,20 @@ click.disable_unicode_literals_warning = True
     ]), 
     help="Where to put SHA256 hash for generated file."
 ) 
+@click.option(
+    '--staging-dir', 
+    'staging_dir',
+    default=None,
+    envvar='GB_STAGING_DIR',
+    help="Where to stage the artifacts of the build."
+) 
+@click.option(
+    '--with-latest', 
+    'with_latest',
+    default=False,
+    envvar='GB_WITH_LATEST',
+    help="Whether to include a latest directory as part of staging."
+)
 
 def main(**kwargs):
     """Entry point for GravityBee CLI."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = gravitybee
 description = Generate standalone python applications.
 long_description = file: README.rst, CHANGELOG.rst
-version = 0.1.12
+version = 0.1.13
 author = YakDriver
 author_email = projects@plus3it.com
 url = https://github.com/YakDriver/gravitybee


### PR DESCRIPTION
- [ENHANCEMENT] Rearrange files created by GravityBee to all be contained in a ``.gravitybee`` subdirectory of the current directory.
- [ENHANCEMENT] Place the distribution artifacts in the staging directory, with a default value of ``.gravitybee/dist``.
- [ENHANCEMENT] Add option ``--staging-dir`` to specify directory where artifact staging should take place and export another environment variable ``GB_ENV_STAGING_DIR``.
- [ENHANCEMENT] Add option ``--with-latest`` to allow creation of a second artifact staging directory called "latest" containing the artifacts renamed with "latest" in the place of the version.
- [ENHANCEMENT] Add option ``--sha-format`` to allow custom naming of the SHA hash file.